### PR TITLE
Add first-class `reference` canvas node with settings, UI, and catalog fixture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,3 +77,4 @@ Build a local-first Next.js app for node-based media generation and post-process
 - For UI or visual polish changes, do not claim completion until you have personally reviewed fresh screenshots or live Chrome MCP output from the changed surface. If the user is asking about layout/styling, include those screenshots in the handoff.
 - When presenting completed work to the user for repo code changes or app-behavior changes, build a fresh mac app artifact with `npm run package:mac` and report the resulting `.app` and `.zip` paths in the handoff.
 - Do not run `npm run package:mac` for Paper MCP-only work, design-only tasks, copy-only tasks, or other requests that do not change the app code in this repository.
+- Always include screenshots relevant to the feature being presented in the handoff, even when not explicitly requested.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,3 +78,5 @@ Build a local-first Next.js app for node-based media generation and post-process
 - When presenting completed work to the user for repo code changes or app-behavior changes, build a fresh mac app artifact with `npm run package:mac` and report the resulting `.app` and `.zip` paths in the handoff.
 - Do not run `npm run package:mac` for Paper MCP-only work, design-only tasks, copy-only tasks, or other requests that do not change the app code in this repository.
 - Always include screenshots relevant to the feature being presented in the handoff, even when not explicitly requested.
+- In screenshot handoff notes, include a direct markdown image link (`![description](artifact_path)`) and 1-2 bullets describing exactly what the user should verify in that image.
+- Feature screenshots must show the actual surface changed (for example: the edited node/component in its active state), not a generic home or landing view.

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -307,3 +307,19 @@ The renderer never sees absolute paths; those refs are resolved only in main/wor
     - `canvasNodeCleanup` boolean
   - timestamps (`created_at`, `updated_at`)
 - defaults: both flags `true` when unset or partially missing
+
+## Reference node settings payload (canvas document)
+
+`WorkflowNode.kind = "reference"` and `WorkflowNode.nodeType = "reference"` represent canonical project entities.
+
+Reference settings are stored in `WorkflowNode.settings` with `source: "reference"` and include:
+
+- `referenceType` (string): category label such as product, person, location, object, brand, material.
+- `subtitle` (string): compact identifying descriptor for canvas readability.
+- `status` (`draft | imported | enriched | user-reviewed | stale | needs-attention`): enrichment lifecycle state.
+- `sourceUrl` (string): optional canonical source pointer.
+- `attributes` (`Record<string, string>`): flexible structured facts.
+- `sourceNotes` (string): unstructured context and guidance.
+- `visualAssetIds` (string[]): optional associated visual asset ids.
+- `provenance` (`manual | url-import | source-material | model-derived`): origin of the current data.
+- `lastEnrichedAt` (ISO string or null): last enrichment timestamp.

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -319,6 +319,7 @@ Reference settings are stored in `WorkflowNode.settings` with `source: "referenc
 - `status` (`draft | imported | enriched | user-reviewed | stale | needs-attention`): enrichment lifecycle state.
 - `sourceUrl` (string): optional canonical source pointer.
 - `attributes` (`Record<string, string>`): flexible structured facts.
+- Reference nodes also persist a synthesized `prompt` string derived from reference settings so model `promptSourceNodeId` links always resolve deterministic prompt text at execution time.
 - `sourceNotes` (string): unstructured context and guidance.
 - `visualAssetIds` (string[]): optional associated visual asset ids.
 - `provenance` (`manual | url-import | source-material | model-derived`): origin of the current data.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -206,3 +206,8 @@
 - Decision: add a persisted app-settings singleton with typed feature flags and expose toggles in `/settings/app`.
 - Initial flags: `capturePng` and `canvasNodeCleanup` gate the corresponding canvas selection-rail actions.
 - Consequence: rollout and rollback are immediate for local users, flags survive restarts, and future toggles can reuse the same path (IPC → service → `app_settings`).
+
+## 2026-03-13 - Canonical Reference Node Establishes Durable Subject Objects
+- Decision: add a first-class `reference` canvas node kind for canonical project entities that persist identity, flexible structured attributes, source pointers, provenance state, and enrichment freshness metadata.
+- Rationale: important subjects (products, people, places, objects) were otherwise spread across notes, prompts, and assets, which made cross-run consistency difficult for users and future agents.
+- Consequences: the node catalog now exposes `Reference Node`, model-input insertion accepts references, and model nodes can treat references similarly to prompt notes as reusable upstream subject context.

--- a/docs/UX_CANVAS_AND_ASSETS.md
+++ b/docs/UX_CANVAS_AND_ASSETS.md
@@ -279,3 +279,18 @@ Controls:
 - asset and preview rendering uses `app-asset://` URLs
 - renderer never sees raw local file paths
 - queue/state updates arrive through preload events and TanStack Query invalidation
+
+## Canonical Reference node
+
+The canvas now includes a dedicated `Reference` node for durable project entities (for example products, people, places, brands, materials, and objects).
+
+### Canvas behavior
+- Appears as an object-like card rather than a sticky note.
+- Surfaces identity and lifecycle badges (type, status, provenance).
+- Shows compact summary content and key structured attributes directly on the node.
+- Supports preview/compact/full/resized display modes and standard canvas positioning behavior.
+
+### Workflow behavior
+- Can be inserted from the node catalog on canvas and model-input insertion flows.
+- Can connect to model nodes as canonical prompt context, similar to prompt notes.
+- Keeps durable, reusable subject context in one object instead of scattering it across notes and repeated prompt text.

--- a/docs/UX_CANVAS_AND_ASSETS.md
+++ b/docs/UX_CANVAS_AND_ASSETS.md
@@ -293,4 +293,5 @@ The canvas now includes a dedicated `Reference` node for durable project entitie
 ### Workflow behavior
 - Can be inserted from the node catalog on canvas and model-input insertion flows.
 - Can connect to model nodes as canonical prompt context, similar to prompt notes.
+- Editing reference fields updates both settings metadata and the node's prompt-source text so prompt-linked model runs receive the latest reference content.
 - Keeps durable, reusable subject context in one object instead of scattering it across notes and repeated prompt text.

--- a/src/components/canvas-focus-preflight.tsx
+++ b/src/components/canvas-focus-preflight.tsx
@@ -26,6 +26,7 @@ function isGeneratedAssetNode(node: CanvasRenderNode) {
 function getPreflightNodeClassName(node: CanvasRenderNode) {
   const classes = [styles.node];
   const isTextNote = node.kind === "text-note";
+  const isReferenceNode = node.kind === "reference";
   const isListNode = node.kind === "list";
   const isTextTemplateNode = node.kind === "text-template";
   const isModelNode = node.kind === "model";
@@ -52,6 +53,9 @@ function getPreflightNodeClassName(node: CanvasRenderNode) {
   }
   if (isGeneratedTextNote) {
     classes.push(nodeStyles.nodeGeneratedTextNote);
+  }
+  if (isReferenceNode) {
+    classes.push(nodeStyles.nodeReference, nodeStyles.nodeSemanticFrame);
   }
   if (isListNode) {
     classes.push(nodeStyles.nodeList, nodeStyles.nodeSemanticFrame);

--- a/src/components/canvas-nodes/canvas-node.module.css
+++ b/src/components/canvas-nodes/canvas-node.module.css
@@ -124,6 +124,48 @@
   border-color: var(--node-accent-text);
 }
 
+
+.nodeReference {
+  width: 320px;
+  min-height: 212px;
+  display: flex;
+  flex-direction: column;
+  padding: 12px 14px;
+  box-shadow: var(--node-shadow-card);
+  border-color: transparent;
+  background-image:
+    linear-gradient(var(--node-surface-paper-raised), var(--node-surface-paper-raised)),
+    var(--node-frame-border-top, linear-gradient(90deg, var(--node-accent-operator), var(--node-accent-operator))),
+    var(--node-frame-border-right, linear-gradient(180deg, var(--node-accent-operator), var(--node-accent-operator))),
+    var(--node-frame-border-bottom, linear-gradient(90deg, var(--node-accent-operator), var(--node-accent-operator))),
+    var(--node-frame-border-left, linear-gradient(180deg, var(--node-accent-operator), var(--node-accent-operator)));
+  background-repeat: no-repeat;
+  background-position:
+    center,
+    top,
+    right,
+    bottom,
+    left;
+  background-size:
+    auto,
+    100% var(--canvas-node-border-width),
+    var(--canvas-node-border-width) 100%,
+    100% var(--canvas-node-border-width),
+    var(--canvas-node-border-width) 100%;
+  background-origin:
+    padding-box,
+    border-box,
+    border-box,
+    border-box,
+    border-box;
+  background-clip:
+    padding-box,
+    border-box,
+    border-box,
+    border-box,
+    border-box;
+}
+
 .nodeGeneratedTextNote {
   border-color: transparent;
   background-image:
@@ -723,6 +765,94 @@
   color: var(--node-surface-ink-soft);
   font-size: var(--ds-font-size-xs);
   line-height: 1.4;
+}
+
+
+.referenceSurface {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-space-2);
+  width: 100%;
+  height: 100%;
+}
+
+.referenceMetaRow {
+  display: flex;
+  align-items: center;
+  gap: var(--ds-space-2);
+  flex-wrap: wrap;
+}
+
+.referenceBadge {
+  font-size: var(--ds-font-size-xs);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--node-surface-ink-muted);
+  border: 1px solid color-mix(in srgb, var(--node-accent-operator) 36%, transparent);
+  border-radius: var(--ds-radius-round);
+  padding: 3px 8px;
+}
+
+
+.referenceInlineInput,
+.referenceSummaryInput,
+.referenceAttributesEditor {
+  width: 100%;
+  border: 1px solid color-mix(in srgb, var(--node-accent-operator) 28%, transparent);
+  background: color-mix(in srgb, var(--node-surface-paper-raised) 92%, var(--node-accent-operator) 8%);
+  border-radius: var(--ds-radius-sm);
+  color: var(--node-surface-ink);
+  font: inherit;
+  outline: none;
+}
+
+.referenceInlineInput,
+.referenceSummaryInput {
+  padding: 6px 8px;
+  font-size: var(--ds-font-size-xs);
+}
+
+.referenceInlineInput {
+  width: auto;
+  min-width: 0;
+  flex: 1 1 120px;
+}
+
+.referenceAttributesEditor {
+  min-height: 72px;
+  resize: vertical;
+  padding: 6px 8px;
+  font-size: var(--ds-font-size-xs);
+  line-height: 1.4;
+}
+
+.referenceSummary {
+  font-size: var(--ds-font-size-sm);
+  color: var(--node-surface-ink-soft);
+  line-height: 1.4;
+}
+
+.referenceFieldLabel {
+  font-size: var(--ds-font-size-xs);
+  color: var(--node-surface-ink-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.referenceKeyValueList {
+  display: grid;
+  grid-template-columns: minmax(90px, 0.8fr) minmax(0, 1.2fr);
+  gap: 6px var(--ds-space-2);
+}
+
+.referenceKey {
+  color: var(--node-surface-ink-muted);
+  font-size: var(--ds-font-size-xs);
+}
+
+.referenceValue {
+  color: var(--node-surface-ink);
+  font-size: var(--ds-font-size-xs);
 }
 
 .noteSurface {

--- a/src/components/canvas-nodes/index.tsx
+++ b/src/components/canvas-nodes/index.tsx
@@ -14,6 +14,7 @@ import type { CanvasRenderNode } from "@/components/canvas-node-types";
 import type {
   ListNodeSettings,
   ProviderModel,
+  ReferenceNodeSettings,
   WorkflowNode,
 } from "@/components/workspace/types";
 import {
@@ -23,6 +24,7 @@ import {
 import {
   buildTemplateVariableInsertText,
   getListNodeSettings,
+  getReferenceNodeSettings,
   getTemplateVariableDisplayLabel,
 } from "@/lib/list-template";
 import { getCanvasNodeTitleChip, type CanvasNodeTitleChip } from "@/lib/canvas-node-title-chip";
@@ -50,6 +52,7 @@ export type ActiveCanvasNodeEditorState = {
   selectedInputNodes: WorkflowNode[];
   selectedPromptSourceNode: WorkflowNode | null;
   selectedListSettings: ListNodeSettings | null;
+  selectedReferenceSettings: ReferenceNodeSettings | null;
   selectedTemplatePreview: TextTemplatePreview | null;
   selectedTemplateListNode: WorkflowNode | null;
   selectedNodeSourceJobId: string | null;
@@ -81,6 +84,7 @@ type Props = {
   onRunNode: () => void;
   onLabelChange: (value: string) => void;
   onPromptChange: (value: string) => void;
+  onReferenceSettingsChange: (nextSettings: ReferenceNodeSettings) => void;
   onModelVariantChange: (variantId: string) => void;
   onParameterChange: (parameterKey: string, value: string | number | null) => void;
   onUpdateListColumnLabel: (columnId: string, label: string) => void;
@@ -1080,6 +1084,7 @@ export function CanvasNodeContent({
   onRunNode,
   onLabelChange,
   onPromptChange,
+  onReferenceSettingsChange,
   onModelVariantChange,
   onParameterChange,
   onUpdateListColumnLabel,
@@ -1099,6 +1104,8 @@ export function CanvasNodeContent({
   const editor = isActive ? activeEditor : null;
   const modelEditor = node.kind === "model" ? editor || passiveModelEditor : null;
   const listSettings = editor?.selectedListSettings || (node.kind === "list" ? getListNodeSettings(node.settings) : null);
+  const referenceSettings =
+    editor?.selectedReferenceSettings || (node.kind === "reference" ? getReferenceNodeSettings(node.settings) : null);
   const isImageAssetNode = node.kind === "asset-source" && node.outputType === "image";
   const templatePreview =
     editor?.selectedTemplatePreview ||
@@ -1229,6 +1236,151 @@ export function CanvasNodeContent({
         onChange={onPromptChange}
         onBlur={onCommitTextEdits}
       />
+    );
+  }
+
+  if (node.kind === "reference" && referenceSettings) {
+    const attributes = Object.entries(referenceSettings.attributes || {});
+    const attributesText = attributes.map(([key, value]) => `${key}: ${value}`).join("\n");
+
+    const handleReferenceSettingPatch = (patch: Partial<ReferenceNodeSettings>) => {
+      onReferenceSettingsChange({
+        ...referenceSettings,
+        ...patch,
+      });
+    };
+
+    const handleAttributesTextChange = (value: string) => {
+      const nextAttributes = value
+        .split("\n")
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0)
+        .reduce<Record<string, string>>((acc, line) => {
+          const separatorIndex = line.indexOf(":");
+          if (separatorIndex <= 0) {
+            return acc;
+          }
+          const key = line.slice(0, separatorIndex).trim();
+          const entryValue = line.slice(separatorIndex + 1).trim();
+          if (!key) {
+            return acc;
+          }
+          acc[key] = entryValue;
+          return acc;
+        }, {});
+
+      handleReferenceSettingPatch({
+        attributes: nextAttributes,
+      });
+    };
+
+    return frame(
+      <div className={styles.referenceSurface}>
+        <div className={styles.referenceMetaRow}>
+          {editor ? (
+            <>
+              <input
+                className={styles.referenceInlineInput}
+                value={referenceSettings.referenceType}
+                onChange={(event) => handleReferenceSettingPatch({ referenceType: event.target.value })}
+                onBlur={onCommitTextEdits}
+                onPointerDown={stopPointer}
+                placeholder="Type"
+              />
+              <select
+                className={styles.referenceInlineInput}
+                value={referenceSettings.status}
+                onChange={(event) => handleReferenceSettingPatch({ status: event.target.value as ReferenceNodeSettings["status"] })}
+                onBlur={onCommitTextEdits}
+                onPointerDown={stopPointer}
+              >
+                <option value="draft">draft</option>
+                <option value="imported">imported</option>
+                <option value="enriched">enriched</option>
+                <option value="user-reviewed">user-reviewed</option>
+                <option value="stale">stale</option>
+                <option value="needs-attention">needs-attention</option>
+              </select>
+              <select
+                className={styles.referenceInlineInput}
+                value={referenceSettings.provenance}
+                onChange={(event) => handleReferenceSettingPatch({ provenance: event.target.value as ReferenceNodeSettings["provenance"] })}
+                onBlur={onCommitTextEdits}
+                onPointerDown={stopPointer}
+              >
+                <option value="manual">manual</option>
+                <option value="url-import">url-import</option>
+                <option value="source-material">source-material</option>
+                <option value="model-derived">model-derived</option>
+              </select>
+            </>
+          ) : (
+            <>
+              <span className={styles.referenceBadge}>{referenceSettings.referenceType || "subject"}</span>
+              <span className={styles.referenceBadge}>{referenceSettings.status}</span>
+              <span className={styles.referenceBadge}>{referenceSettings.provenance}</span>
+            </>
+          )}
+        </div>
+
+        {editor ? (
+          <input
+            className={styles.referenceSummaryInput}
+            value={referenceSettings.subtitle}
+            onChange={(event) => handleReferenceSettingPatch({ subtitle: event.target.value })}
+            onBlur={onCommitTextEdits}
+            onPointerDown={stopPointer}
+            placeholder="Short descriptor"
+          />
+        ) : (
+          <div className={styles.referenceSummary}>
+            {referenceSettings.subtitle?.trim() || node.prompt.trim() || "Canonical project reference"}
+          </div>
+        )}
+
+        <div>
+          <div className={styles.referenceFieldLabel}>Source URL</div>
+          {editor ? (
+            <input
+              className={styles.referenceSummaryInput}
+              value={referenceSettings.sourceUrl}
+              onChange={(event) => handleReferenceSettingPatch({ sourceUrl: event.target.value })}
+              onBlur={onCommitTextEdits}
+              onPointerDown={stopPointer}
+              placeholder="https://..."
+            />
+          ) : referenceSettings.sourceUrl.trim() ? (
+            <div className={styles.referenceValue}>{referenceSettings.sourceUrl}</div>
+          ) : (
+            <div className={styles.referenceValue}>No source URL</div>
+          )}
+        </div>
+
+        <div>
+          <div className={styles.referenceFieldLabel}>Attributes</div>
+          {editor ? (
+            <textarea
+              className={styles.referenceAttributesEditor}
+              value={attributesText}
+              onChange={(event) => handleAttributesTextChange(event.target.value)}
+              onBlur={onCommitTextEdits}
+              onPointerDown={stopPointer}
+              placeholder="dimensions: W 82cm × D 88cm × H 76cm"
+            />
+          ) : attributes.length > 0 ? (
+            <div className={styles.referenceKeyValueList}>
+              {attributes.slice(0, 4).map(([key, value]) => (
+                <div key={key} style={{ display: "contents" }}>
+                  <span className={styles.referenceKey}>{key}</span>
+                  <span className={styles.referenceValue}>{value}</span>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className={styles.referenceValue}>No structured attributes</div>
+          )}
+        </div>
+      </div>
     );
   }
 

--- a/src/components/infinite-canvas.tsx
+++ b/src/components/infinite-canvas.tsx
@@ -1367,6 +1367,7 @@ export function InfiniteCanvas({
 
         {displayNodes.map((node) => {
           const isTextNote = node.kind === "text-note";
+          const isReferenceNode = node.kind === "reference";
           const isListNode = node.kind === "list";
           const isTextTemplateNode = node.kind === "text-template";
           const isModelNode = node.kind === "model";
@@ -1473,7 +1474,7 @@ export function InfiniteCanvas({
               tabIndex={0}
               data-node-id={node.id}
               data-rail-drag={node.presentation.useRailDragHandle ? "true" : "false"}
-              className={`${styles.node} ${isSelected ? styles.nodeSelected : ""} ${programmaticMotionNodeIdSet.has(node.id) ? styles.nodeProgrammaticMotion : ""} ${shouldRenderImageFrame ? nodeStyles.nodeWithImage : ""} ${isGeneratedAsset ? nodeStyles.nodeGeneratedAsset : ""} ${isUploadedAsset ? nodeStyles.nodeUploadedAsset : ""} ${isTextNote ? nodeStyles.nodeTextNote : ""} ${isTextNote && !isGeneratedTextNote ? nodeStyles.nodeSemanticFrame : ""} ${isGeneratedTextNote ? nodeStyles.nodeGeneratedTextNote : ""} ${isListNode ? nodeStyles.nodeList : ""} ${isListNode ? nodeStyles.nodeSemanticFrame : ""} ${isTextTemplateNode ? nodeStyles.nodeTextTemplate : ""} ${isModelNode || isOperatorNode ? nodeStyles.nodeModel : ""} ${activeConnectionNodeIds.has(node.id) ? styles.nodePortActive : ""} ${showsProcessingShell ? nodeStyles.nodeGeneratedProcessing : ""} ${node.renderMode === "compact" ? nodeStyles.nodeCompactMode : ""} ${node.renderMode === "full" ? nodeStyles.nodeFullMode : ""} ${node.renderMode === "resized" ? nodeStyles.nodeResizedMode : ""}`}
+              className={`${styles.node} ${isSelected ? styles.nodeSelected : ""} ${programmaticMotionNodeIdSet.has(node.id) ? styles.nodeProgrammaticMotion : ""} ${shouldRenderImageFrame ? nodeStyles.nodeWithImage : ""} ${isGeneratedAsset ? nodeStyles.nodeGeneratedAsset : ""} ${isUploadedAsset ? nodeStyles.nodeUploadedAsset : ""} ${isTextNote ? nodeStyles.nodeTextNote : ""} ${isTextNote && !isGeneratedTextNote ? nodeStyles.nodeSemanticFrame : ""} ${isGeneratedTextNote ? nodeStyles.nodeGeneratedTextNote : ""} ${isReferenceNode ? nodeStyles.nodeReference : ""} ${isListNode ? nodeStyles.nodeList : ""} ${isListNode ? nodeStyles.nodeSemanticFrame : ""} ${isReferenceNode ? nodeStyles.nodeSemanticFrame : ""} ${isTextTemplateNode ? nodeStyles.nodeTextTemplate : ""} ${isModelNode || isOperatorNode ? nodeStyles.nodeModel : ""} ${activeConnectionNodeIds.has(node.id) ? styles.nodePortActive : ""} ${showsProcessingShell ? nodeStyles.nodeGeneratedProcessing : ""} ${node.renderMode === "compact" ? nodeStyles.nodeCompactMode : ""} ${node.renderMode === "full" ? nodeStyles.nodeFullMode : ""} ${node.renderMode === "resized" ? nodeStyles.nodeResizedMode : ""}`}
               style={nodeStyle}
               onClick={(event) => {
                 event.stopPropagation();

--- a/src/components/infinite-canvas.tsx
+++ b/src/components/infinite-canvas.tsx
@@ -1389,6 +1389,7 @@ export function InfiniteCanvas({
           const showOutputPort =
             isListNode ||
             isTextNote ||
+            isReferenceNode ||
             isOperatorNode ||
             (node.kind === "asset-source" && !isModelNode) ||
             (isModelNode && node.outputType !== "text" && Boolean(node.hasStartedJob));

--- a/src/components/workspace/types.ts
+++ b/src/components/workspace/types.ts
@@ -78,8 +78,16 @@ export type AppFeatureFlagKey = keyof AppFeatureFlags;
 
 export type JobRunOrigin = "canvas-node" | "copilot";
 
-export type WorkflowNodeKind = "model" | "asset-source" | "text-note" | "list" | "text-template";
-export type WorkflowNodeType = "text-gen" | "image-gen" | "video-gen" | "transform" | "text-note" | "list" | "text-template";
+export type WorkflowNodeKind = "model" | "asset-source" | "text-note" | "reference" | "list" | "text-template";
+export type WorkflowNodeType =
+  | "text-gen"
+  | "image-gen"
+  | "video-gen"
+  | "transform"
+  | "text-note"
+  | "reference"
+  | "list"
+  | "text-template";
 export type RunnableWorkflowNodeType = "text-gen" | "image-gen" | "video-gen" | "transform";
 export type WorkflowNodeDisplayMode = "preview" | "compact" | "full" | "resized";
 export type WorkflowNodeSize = {
@@ -123,6 +131,22 @@ export type BaseTextTemplateNodeSettings = {
 
 export type TextNoteSettings = {
   source: "text-note";
+};
+
+export type ReferenceNodeSource = "manual" | "url-import" | "source-material" | "model-derived";
+export type ReferenceNodeStatus = "draft" | "imported" | "enriched" | "user-reviewed" | "stale" | "needs-attention";
+
+export type ReferenceNodeSettings = {
+  source: "reference";
+  referenceType: string;
+  subtitle: string;
+  status: ReferenceNodeStatus;
+  sourceUrl: string;
+  attributes: Record<string, string>;
+  sourceNotes: string;
+  visualAssetIds: string[];
+  provenance: ReferenceNodeSource;
+  lastEnrichedAt: string | null;
 };
 
 export type GeneratedTextNoteSettings = {

--- a/src/components/workspace/views/canvas-view.tsx
+++ b/src/components/workspace/views/canvas-view.tsx
@@ -91,6 +91,7 @@ import {
   type CanvasDocument,
   type Job,
   type ListNodeSettings,
+  type ReferenceNodeSettings,
   type ProviderModel,
   type RunnableWorkflowNodeType,
   type WorkflowNode,
@@ -100,11 +101,13 @@ import {
   buildTextTemplatePreview,
   createDefaultListNodeSettings,
   createGeneratedTextNoteSettings,
+  createReferenceNodeSettings,
   createTextNoteSettings,
   createTextTemplateNodeSettings,
   getGeneratedModelNodeSource,
   getGeneratedTextNoteSettings,
   getListNodeSettings,
+  getReferenceNodeSettings,
   getTextTemplateNodeSettings,
   isGeneratedTextNoteNode,
 } from "@/lib/list-template";
@@ -480,7 +483,7 @@ function applyCanvasNodeConnection(
     };
   }
 
-  const inferredKind: GeneratedConnectionDescriptor["kind"] = sourceNode.kind === "text-note" ? "prompt" : "input";
+  const inferredKind: GeneratedConnectionDescriptor["kind"] = (sourceNode.kind === "text-note" || sourceNode.kind === "reference") ? "prompt" : "input";
   if (expectedKind && expectedKind !== inferredKind) {
     return {
       nodes,
@@ -488,7 +491,7 @@ function applyCanvasNodeConnection(
     };
   }
 
-  if (targetNode.kind === "text-note") {
+  if (targetNode.kind === "text-note" || targetNode.kind === "reference") {
     if (
       targetNode.upstreamNodeIds.length === 1 &&
       targetNode.upstreamNodeIds[0] === sourceNodeId &&
@@ -515,7 +518,7 @@ function applyCanvasNodeConnection(
     };
   }
 
-  if (sourceNode.kind === "text-note") {
+  if (sourceNode.kind === "text-note" || sourceNode.kind === "reference") {
     if (targetNode.promptSourceNodeId === sourceNodeId) {
       return {
         nodes,
@@ -1411,6 +1414,7 @@ export function CanvasView({ projectId }: Props) {
   }, []);
 
   const selectedNodeIsList = selectedNode?.kind === "list";
+  const selectedNodeIsReference = selectedNode?.kind === "reference";
   const selectedNodeIsTextTemplate = selectedNode?.kind === "text-template";
   const selectedNodeIsModel = selectedNode?.kind === "model";
   const selectedModel = useMemo(() => {
@@ -1784,6 +1788,14 @@ export function CanvasView({ projectId }: Props) {
     }
     return getListNodeSettings(selectedNode.settings);
   }, [selectedNode, selectedNodeIsList]);
+
+  const selectedReferenceSettings = useMemo<ReferenceNodeSettings | null>(() => {
+    if (!selectedNodeIsReference || !selectedNode) {
+      return null;
+    }
+
+    return getReferenceNodeSettings(selectedNode.settings);
+  }, [selectedNode, selectedNodeIsReference]);
 
   const selectedTemplateListNode = useMemo(() => {
     if (!selectedNodeIsTextTemplate || !selectedNode) {
@@ -2966,11 +2978,12 @@ export function CanvasView({ projectId }: Props) {
           sourceJobId: null,
           sourceOutputIndex: null,
           processingState: null,
-          promptSourceNodeId: connectFromNode?.kind === "text-note" ? connectFromNode.id : null,
+          promptSourceNodeId:
+            connectFromNode?.kind === "text-note" || connectFromNode?.kind === "reference" ? connectFromNode.id : null,
           upstreamNodeIds:
-            connectFromNode && connectFromNode.kind !== "text-note" ? [connectFromNode.id] : [],
+            connectFromNode && connectFromNode.kind !== "text-note" && connectFromNode.kind !== "reference" ? [connectFromNode.id] : [],
           upstreamAssetIds:
-            connectFromNode && connectFromNode.kind !== "text-note"
+            connectFromNode && connectFromNode.kind !== "text-note" && connectFromNode.kind !== "reference"
               ? buildAssetRefsFromNodes([connectFromNode.id], prev.workflow.nodes)
               : [],
           x: nextPosition.x,
@@ -3068,6 +3081,65 @@ export function CanvasView({ projectId }: Props) {
 
         return {
           canvasDoc: nextDoc,
+          selectedNodeIds: [node.id],
+          selectedConnection: null,
+        };
+      });
+      if (didMutate && options?.centerOnPosition) {
+        setPendingCenteredInsert({
+          nodeId,
+          anchor: options.centerOnPosition,
+        });
+      }
+      setInsertMenu(null);
+      setActiveFullNodeId(null);
+    },
+    [providers, runUserCanvasMutation]
+  );
+
+  const addReferenceNode = useCallback(
+    (
+      position?: { x: number; y: number },
+      options?: { centerOnPosition?: { x: number; y: number } }
+    ) => {
+      const defaultProvider = getFallbackProviderModel(providers);
+      const nodeId = uid();
+      const didMutate = runUserCanvasMutation((currentState) => {
+        const prev = currentState.canvasDoc;
+        const nextPosition = nextCanvasNodePosition(prev.workflow.nodes.length, position);
+        const zIndex = nextCanvasNodeZIndex(prev.workflow.nodes);
+        const node: WorkflowNode = {
+          id: nodeId,
+          label: `Reference ${prev.workflow.nodes.filter((item) => item.kind === "reference").length + 1}`,
+          kind: "reference",
+          providerId: defaultProvider.providerId,
+          modelId: defaultProvider.modelId,
+          nodeType: "reference",
+          outputType: "text",
+          prompt: "",
+          settings: createReferenceNodeSettings(),
+          sourceAssetId: null,
+          sourceAssetMimeType: null,
+          sourceJobId: null,
+          sourceOutputIndex: null,
+          processingState: null,
+          promptSourceNodeId: null,
+          upstreamNodeIds: [],
+          upstreamAssetIds: [],
+          x: nextPosition.x,
+          y: nextPosition.y,
+          zIndex,
+          displayMode: "preview",
+          size: null,
+        };
+
+        return {
+          canvasDoc: {
+            ...prev,
+            workflow: {
+              nodes: [...prev.workflow.nodes, node],
+            },
+          },
           selectedNodeIds: [node.id],
           selectedConnection: null,
         };
@@ -3278,7 +3350,7 @@ export function CanvasView({ projectId }: Props) {
 
   const handleInsertCatalogEntry = useCallback(
     (
-      entryId: "model" | "text-note" | "list" | "text-template" | "asset-uploaded" | "asset-generated",
+      entryId: "model" | "text-note" | "reference" | "list" | "text-template" | "asset-uploaded" | "asset-generated",
       menuState: CanvasInsertMenuState | null,
       position: { x: number; y: number },
       options?: { providerId?: WorkflowNode["providerId"]; modelId?: string }
@@ -3305,6 +3377,11 @@ export function CanvasView({ projectId }: Props) {
             centerOnPosition: position,
           }
         );
+        return;
+      }
+
+      if (entryId === "reference") {
+        addReferenceNode(getCenteredInsertPosition(position), { centerOnPosition: position });
         return;
       }
 
@@ -3346,7 +3423,7 @@ export function CanvasView({ projectId }: Props) {
         connectToModelNodeId: menuState.mode === "model-input" ? menuState.connectToNodeId : undefined,
       });
     },
-    [addListNode, addModelNode, addTextNote, addTextTemplateNode]
+    [addListNode, addModelNode, addReferenceNode, addTextNote, addTextTemplateNode]
   );
 
   const updateNode = useCallback(
@@ -4142,6 +4219,26 @@ export function CanvasView({ projectId }: Props) {
     [selectedNode, updateNode]
   );
 
+  const handleSelectedReferenceSettingsChange = useCallback(
+    (nextSettings: ReferenceNodeSettings) => {
+      if (!selectedNode || !selectedNodeIsReference) {
+        return;
+      }
+
+      updateNode(
+        selectedNode.id,
+        {
+          settings: nextSettings,
+        },
+        {
+          historyMode: "coalesced",
+          historyKey: `node:${selectedNode.id}:reference-settings`,
+        }
+      );
+    },
+    [selectedNode, selectedNodeIsReference, updateNode]
+  );
+
   const handleSelectedNodeModelVariantChange = useCallback(
     (variantId: string) => {
       if (!selectedNode || !selectedNodeIsModel) {
@@ -4417,7 +4514,7 @@ export function CanvasView({ projectId }: Props) {
 
       if (request.connectionNodeId && request.connectionPort === "output") {
         const sourceNode = nodesById[request.connectionNodeId];
-        if (sourceNode && (sourceNode.kind === "text-note" || sourceNode.kind === "asset-source")) {
+        if (sourceNode && (sourceNode.kind === "text-note" || sourceNode.kind === "reference" || sourceNode.kind === "asset-source")) {
           addModelNode({ x: request.x, y: request.y }, { connectFromNodeId: sourceNode.id });
           return;
         }
@@ -4548,7 +4645,7 @@ export function CanvasView({ projectId }: Props) {
                     upstreamNodeIds: [],
                     upstreamAssetIds: [],
                   }
-                : sourceNode.kind === "text-note"
+                : sourceNode.kind === "text-note" || sourceNode.kind === "reference"
                   ? {
                       ...sourceNode,
                       settings: isGeneratedTextNoteNode(sourceNode) ? createTextNoteSettings() : sourceNode.settings,
@@ -4735,6 +4832,11 @@ export function CanvasView({ projectId }: Props) {
         return;
       }
 
+      if (command.nodeType === "reference") {
+        addReferenceNode(position);
+        return;
+      }
+
       if (command.nodeType === "list") {
         addListNode(position);
         return;
@@ -4754,6 +4856,7 @@ export function CanvasView({ projectId }: Props) {
   }, [
     addListNode,
     addModelNode,
+    addReferenceNode,
     addTextNote,
     addTextTemplateNode,
     connectSelectedNodes,
@@ -5816,6 +5919,7 @@ export function CanvasView({ projectId }: Props) {
       selectedInputNodes,
       selectedPromptSourceNode,
       selectedListSettings,
+      selectedReferenceSettings,
       selectedTemplatePreview,
       selectedTemplateListNode,
       selectedNodeSourceJobId,
@@ -5834,6 +5938,7 @@ export function CanvasView({ projectId }: Props) {
     selectedNodeRunPreview,
     selectedNodeSourceJobId,
     selectedPromptSourceNode,
+    selectedReferenceSettings,
     selectedSingleImageAssetId,
     selectedTemplateListNode,
     selectedTemplatePreview,
@@ -5912,6 +6017,7 @@ export function CanvasView({ projectId }: Props) {
           }}
           onLabelChange={handleSelectedNodeLabelChange}
           onPromptChange={handleSelectedNodePromptChange}
+          onReferenceSettingsChange={handleSelectedReferenceSettingsChange}
           onModelVariantChange={handleSelectedNodeModelVariantChange}
           onParameterChange={updateSelectedModelParameter}
           onUpdateListColumnLabel={updateSelectedListColumnLabel}
@@ -5944,6 +6050,7 @@ export function CanvasView({ projectId }: Props) {
       handleSelectedNodeLabelChange,
       handleSelectedNodePromptChange,
       handleSelectedNodeModelVariantChange,
+      handleSelectedReferenceSettingsChange,
       nodesById,
       openAssetViewer,
       openQueueInspect,

--- a/src/components/workspace/views/canvas-view.tsx
+++ b/src/components/workspace/views/canvas-view.tsx
@@ -100,6 +100,7 @@ import {
 import {
   buildTextTemplatePreview,
   createDefaultListNodeSettings,
+  buildReferencePromptText,
   createGeneratedTextNoteSettings,
   createReferenceNodeSettings,
   createTextNoteSettings,
@@ -3108,6 +3109,7 @@ export function CanvasView({ projectId }: Props) {
         const prev = currentState.canvasDoc;
         const nextPosition = nextCanvasNodePosition(prev.workflow.nodes.length, position);
         const zIndex = nextCanvasNodeZIndex(prev.workflow.nodes);
+        const settings = createReferenceNodeSettings();
         const node: WorkflowNode = {
           id: nodeId,
           label: `Reference ${prev.workflow.nodes.filter((item) => item.kind === "reference").length + 1}`,
@@ -3116,8 +3118,8 @@ export function CanvasView({ projectId }: Props) {
           modelId: defaultProvider.modelId,
           nodeType: "reference",
           outputType: "text",
-          prompt: "",
-          settings: createReferenceNodeSettings(),
+          prompt: buildReferencePromptText(settings),
+          settings,
           sourceAssetId: null,
           sourceAssetMimeType: null,
           sourceJobId: null,
@@ -4229,6 +4231,7 @@ export function CanvasView({ projectId }: Props) {
         selectedNode.id,
         {
           settings: nextSettings,
+          prompt: buildReferencePromptText(nextSettings),
         },
         {
           historyMode: "coalesced",

--- a/src/lib/canvas-connection-rules.ts
+++ b/src/lib/canvas-connection-rules.ts
@@ -20,7 +20,7 @@ export function canConnectCanvasNodes(sourceNode: WorkflowNode | null | undefine
     );
   }
 
-  if (sourceNode.kind === "text-note") {
+  if (sourceNode.kind === "text-note" || sourceNode.kind === "reference") {
     return targetNode.kind === "model";
   }
 

--- a/src/lib/canvas-document.test.ts
+++ b/src/lib/canvas-document.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { normalizeCanvasNode } from "@/lib/canvas-document";
+
+test("normalizeCanvasNode preserves reference node kind and settings", () => {
+  const normalized = normalizeCanvasNode(
+    {
+      id: "reference-1",
+      label: "Reference 1",
+      kind: "reference",
+      providerId: "openai",
+      modelId: "gpt-image-1.5",
+      settings: {
+        source: "reference",
+        referenceType: "person",
+        subtitle: "Creative Director",
+        status: "enriched",
+        sourceUrl: "https://example.com/person",
+        attributes: {
+          hair: "auburn",
+        },
+        sourceNotes: "Imported from brief",
+        visualAssetIds: ["asset-1"],
+        provenance: "url-import",
+        lastEnrichedAt: "2026-03-12T09:30:00.000Z",
+      },
+    },
+    0
+  );
+
+  assert.equal(normalized.kind, "reference");
+  assert.equal(normalized.nodeType, "reference");
+  assert.equal(normalized.outputType, "text");
+  assert.deepEqual(normalized.settings, {
+    source: "reference",
+    referenceType: "person",
+    subtitle: "Creative Director",
+    status: "enriched",
+    sourceUrl: "https://example.com/person",
+    attributes: {
+      hair: "auburn",
+    },
+    sourceNotes: "Imported from brief",
+    visualAssetIds: ["asset-1"],
+    provenance: "url-import",
+    lastEnrichedAt: "2026-03-12T09:30:00.000Z",
+  });
+});

--- a/src/lib/canvas-document.ts
+++ b/src/lib/canvas-document.ts
@@ -4,7 +4,12 @@ import {
   type ProviderId,
   type WorkflowNode,
 } from "@/components/workspace/types";
-import { normalizeTextNoteSettings, getListNodeSettings, getTextTemplateNodeSettings } from "@/lib/list-template";
+import {
+  normalizeTextNoteSettings,
+  getListNodeSettings,
+  getReferenceNodeSettings,
+  getTextTemplateNodeSettings,
+} from "@/lib/list-template";
 import { normalizeWorkflowNodeDisplayMode, normalizeWorkflowNodeSize } from "@/lib/canvas-node-presentation";
 import { normalizeLegacyTopazModelId } from "@/lib/topaz-gigapixel-settings";
 
@@ -28,6 +33,7 @@ export function normalizeCanvasNode(raw: Record<string, unknown>, index: number)
     raw.kind === "model" ||
     raw.kind === "asset-source" ||
     raw.kind === "text-note" ||
+    raw.kind === "reference" ||
     raw.kind === "list" ||
     raw.kind === "text-template"
       ? (raw.kind as WorkflowNode["kind"])
@@ -47,6 +53,8 @@ export function normalizeCanvasNode(raw: Record<string, unknown>, index: number)
         ? getTextTemplateNodeSettings(baseSettings)
         : inferredKind === "text-note"
           ? normalizeTextNoteSettings(baseSettings)
+          : inferredKind === "reference"
+            ? getReferenceNodeSettings(baseSettings)
           : baseSettings;
 
   return {
@@ -63,10 +71,17 @@ export function normalizeCanvasNode(raw: Record<string, unknown>, index: number)
             ? "list"
             : inferredKind === "text-template"
               ? "text-template"
+              : inferredKind === "reference"
+                ? "reference"
               : "image-gen")),
     outputType:
       (raw.outputType as WorkflowNode["outputType"]) ||
-      (inferredKind === "list" || inferredKind === "text-template" || inferredKind === "text-note" ? "text" : "image"),
+      (inferredKind === "list" ||
+      inferredKind === "text-template" ||
+      inferredKind === "text-note" ||
+      inferredKind === "reference"
+        ? "text"
+        : "image"),
     prompt: String(raw.prompt || ""),
     sourceAssetId: raw.sourceAssetId ? String(raw.sourceAssetId) : null,
     sourceAssetMimeType: raw.sourceAssetMimeType ? String(raw.sourceAssetMimeType) : null,

--- a/src/lib/canvas-node-design-system.ts
+++ b/src/lib/canvas-node-design-system.ts
@@ -82,7 +82,7 @@ export function resolveCanvasNodeBorderSemantics(
   let fallbackLeftAccentType: CanvasAccentType = "neutral";
   if (provenanceAccent) {
     fallbackLeftAccentType = provenanceAccent;
-  } else if (input.kind === "text-note" || input.kind === "list") {
+  } else if (input.kind === "text-note" || input.kind === "reference" || input.kind === "list") {
     fallbackLeftAccentType = input.outputAccentType;
   } else if (input.kind === "asset-source" && input.assetOrigin === "uploaded") {
     fallbackLeftAccentType = input.outputAccentType;

--- a/src/lib/canvas-node-presentation.ts
+++ b/src/lib/canvas-node-presentation.ts
@@ -10,6 +10,7 @@ export type CanvasNodeRenderMode = WorkflowNodeDisplayMode | "full";
 export type CanvasNodeInteractionPolicy =
   | "model"
   | "text-note"
+  | "reference"
   | "list"
   | "text-template"
   | "image-asset"
@@ -34,6 +35,7 @@ export type ResolvedCanvasNodePresentation = {
 
 const MIN_MODEL_SIZE: WorkflowNodeSize = { width: 460, height: 320 };
 const MIN_TEXT_NOTE_SIZE: WorkflowNodeSize = { width: 244, height: 152 };
+const MIN_REFERENCE_SIZE: WorkflowNodeSize = { width: 320, height: 212 };
 const MIN_TEMPLATE_SIZE: WorkflowNodeSize = { width: 420, height: 300 };
 const MIN_ASSET_SIZE: WorkflowNodeSize = { width: 196, height: 196 };
 
@@ -68,6 +70,7 @@ export function canResizeWorkflowNode(node: Pick<WorkflowNode, "kind">) {
   return (
     node.kind === "model" ||
     node.kind === "text-note" ||
+    node.kind === "reference" ||
     node.kind === "list" ||
     node.kind === "text-template" ||
     node.kind === "asset-source"
@@ -88,6 +91,10 @@ export function getWorkflowNodeResizeMinimumSize(
 
   if (node.kind === "text-note") {
     return MIN_TEXT_NOTE_SIZE;
+  }
+
+  if (node.kind === "reference") {
+    return MIN_REFERENCE_SIZE;
   }
 
   if (node.kind === "list") {
@@ -140,6 +147,16 @@ export function getWorkflowNodeDefaultSize(
     return MIN_TEXT_NOTE_SIZE;
   }
 
+  if (kind === "reference") {
+    if (renderMode === "compact") {
+      return { width: 176, height: 44 };
+    }
+    if (renderMode === "full") {
+      return { width: 560, height: 380 };
+    }
+    return MIN_REFERENCE_SIZE;
+  }
+
   if (kind === "list") {
     if (renderMode === "compact") {
       return { width: 156, height: 46 };
@@ -190,6 +207,10 @@ export function getCanvasNodeInteractionPolicy(
 
   if (node.kind === "text-note") {
     return "text-note";
+  }
+
+  if (node.kind === "reference") {
+    return "reference";
   }
 
   if (node.kind === "list") {

--- a/src/lib/canvas-node-title-chip.ts
+++ b/src/lib/canvas-node-title-chip.ts
@@ -39,6 +39,14 @@ export function getCanvasNodeTitleChip(node: Input): CanvasNodeTitleChip {
     };
   }
 
+  if (node.kind === "reference") {
+    return {
+      label: "Reference",
+      accentType: "operator",
+      color: getCanvasNodeAccentColor("operator"),
+    };
+  }
+
   if (node.kind === "list") {
     return {
       label: "List / Sheet",

--- a/src/lib/canvas-primary-editor.ts
+++ b/src/lib/canvas-primary-editor.ts
@@ -37,7 +37,7 @@ export function resolvePrimaryCanvasEditorId(
     return "prompt";
   }
 
-  if (node.kind === "text-note") {
+  if (node.kind === "text-note" || node.kind === "reference") {
     return "note";
   }
 

--- a/src/lib/ipc-contract.ts
+++ b/src/lib/ipc-contract.ts
@@ -30,6 +30,7 @@ export type AppEventPayload = {
 export type CanvasMenuNodeType =
   | "model"
   | "text-note"
+  | "reference"
   | "list"
   | "text-template"
   | "asset-uploaded"

--- a/src/lib/list-template.test.ts
+++ b/src/lib/list-template.test.ts
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import {
   buildTemplateVariableInsertText,
+  buildReferencePromptText,
   buildTextTemplatePreview,
   createListColumn,
   createListRow,
@@ -98,5 +99,36 @@ test("buildTextTemplatePreview skips fully blank rows and preserves row order", 
   assert.deepEqual(
     preview.rows.map((row) => row.text),
     ["Meet Akita with Fluffy.", "Meet Beagle with Short."]
+  );
+});
+
+
+test("buildReferencePromptText composes prompt content from key reference fields", () => {
+  const prompt = buildReferencePromptText({
+    source: "reference",
+    referenceType: "product",
+    subtitle: "Walnut lounge chair",
+    status: "draft",
+    sourceUrl: "https://example.com/chair",
+    attributes: {
+      Material: "Solid walnut",
+      Width: "82cm",
+    },
+    sourceNotes: "",
+    visualAssetIds: [],
+    provenance: "manual",
+    lastEnrichedAt: null,
+  });
+
+  assert.equal(
+    prompt,
+    [
+      "Type: product",
+      "Summary: Walnut lounge chair",
+      "Source URL: https://example.com/chair",
+      "Attributes:",
+      "- Material: Solid walnut",
+      "- Width: 82cm",
+    ].join("\n")
   );
 });

--- a/src/lib/list-template.ts
+++ b/src/lib/list-template.ts
@@ -9,11 +9,13 @@ import type {
   TextNoteSettings,
   TextTemplateNodeSettings,
   WorkflowNode,
+  ReferenceNodeSettings,
 } from "@/components/workspace/types";
 
 export const LIST_NODE_SOURCE = "list";
 export const TEXT_TEMPLATE_SOURCE = "text-template";
 export const TEXT_NOTE_SOURCE = "text-note";
+export const REFERENCE_SOURCE = "reference";
 export const TEMPLATE_OUTPUT_SOURCE = "template-output";
 export const MODEL_OUTPUT_TEXT_SOURCE = "generated-model-text";
 export const MODEL_OUTPUT_LIST_SOURCE = "generated-model-list";
@@ -116,6 +118,69 @@ export function createTextTemplateNodeSettings(): TextTemplateNodeSettings {
 export function createTextNoteSettings(): TextNoteSettings {
   return {
     source: TEXT_NOTE_SOURCE,
+  };
+}
+
+export function createReferenceNodeSettings(): ReferenceNodeSettings {
+  return {
+    source: REFERENCE_SOURCE,
+    referenceType: "product",
+    subtitle: "",
+    status: "draft",
+    sourceUrl: "",
+    attributes: {},
+    sourceNotes: "",
+    visualAssetIds: [],
+    provenance: "manual",
+    lastEnrichedAt: null,
+  };
+}
+
+export function getReferenceNodeSettings(value: unknown): ReferenceNodeSettings {
+  const record = asRecord(value);
+  const attributesRecord = asRecord(record.attributes);
+  const attributes = Object.entries(attributesRecord).reduce<Record<string, string>>((acc, entry) => {
+    const [key, rawValue] = entry;
+    const normalizedKey = String(key || "").trim();
+    if (!normalizedKey) {
+      return acc;
+    }
+    acc[normalizedKey] = String(rawValue ?? "");
+    return acc;
+  }, {});
+
+  const visualAssetIds = Array.isArray(record.visualAssetIds)
+    ? record.visualAssetIds
+        .map((assetId) => String(assetId || "").trim())
+        .filter((assetId) => assetId.length > 0)
+    : [];
+
+  return {
+    source: REFERENCE_SOURCE,
+    referenceType: String(record.referenceType || "").trim() || "subject",
+    subtitle: String(record.subtitle ?? ""),
+    status:
+      record.status === "imported" ||
+      record.status === "enriched" ||
+      record.status === "user-reviewed" ||
+      record.status === "stale" ||
+      record.status === "needs-attention"
+        ? record.status
+        : "draft",
+    sourceUrl: String(record.sourceUrl ?? ""),
+    attributes,
+    sourceNotes: String(record.sourceNotes ?? ""),
+    visualAssetIds,
+    provenance:
+      record.provenance === "url-import" ||
+      record.provenance === "source-material" ||
+      record.provenance === "model-derived"
+        ? record.provenance
+        : "manual",
+    lastEnrichedAt:
+      typeof record.lastEnrichedAt === "string" && record.lastEnrichedAt.trim().length > 0
+        ? String(record.lastEnrichedAt)
+        : null,
   };
 }
 

--- a/src/lib/list-template.ts
+++ b/src/lib/list-template.ts
@@ -136,6 +136,37 @@ export function createReferenceNodeSettings(): ReferenceNodeSettings {
   };
 }
 
+export function buildReferencePromptText(settings: ReferenceNodeSettings): string {
+  const lines: string[] = [];
+  const referenceType = settings.referenceType.trim();
+  const subtitle = settings.subtitle.trim();
+  const sourceUrl = settings.sourceUrl.trim();
+  const attributes = Object.entries(settings.attributes || {})
+    .map(([key, value]) => [String(key).trim(), String(value).trim()] as const)
+    .filter(([key, value]) => key.length > 0 && value.length > 0);
+
+  if (referenceType) {
+    lines.push(`Type: ${referenceType}`);
+  }
+
+  if (subtitle) {
+    lines.push(`Summary: ${subtitle}`);
+  }
+
+  if (sourceUrl) {
+    lines.push(`Source URL: ${sourceUrl}`);
+  }
+
+  if (attributes.length > 0) {
+    lines.push("Attributes:");
+    attributes.forEach(([key, value]) => {
+      lines.push(`- ${key}: ${value}`);
+    });
+  }
+
+  return lines.join("\n");
+}
+
 export function getReferenceNodeSettings(value: unknown): ReferenceNodeSettings {
   const record = asRecord(value);
   const attributesRecord = asRecord(record.attributes);

--- a/src/lib/node-catalog.test.ts
+++ b/src/lib/node-catalog.test.ts
@@ -106,7 +106,7 @@ test("node catalog exposes the built-in library surface", () => {
 
   assert.deepEqual(
     entries.map((entry) => entry.id),
-    ["model", "text-note", "list", "text-template", "asset-uploaded", "asset-generated"]
+    ["model", "text-note", "reference", "list", "text-template", "asset-uploaded", "asset-generated"]
   );
 });
 
@@ -217,11 +217,11 @@ test("model catalog variants surface Gemini access states and paid-tier labels",
 test("insertable catalog entries respect canvas insertion context", () => {
   assert.deepEqual(
     getInsertableNodeCatalogEntries("canvas", sampleProviders).map((entry) => entry.id),
-    ["model", "text-note", "list", "text-template", "asset-uploaded", "asset-generated"]
+    ["model", "text-note", "reference", "list", "text-template", "asset-uploaded", "asset-generated"]
   );
   assert.deepEqual(
     getInsertableNodeCatalogEntries("model-input", sampleProviders).map((entry) => entry.id),
-    ["text-note", "asset-uploaded", "asset-generated"]
+    ["text-note", "reference", "asset-uploaded", "asset-generated"]
   );
   assert.deepEqual(
     getInsertableNodeCatalogEntries("template-input", sampleProviders).map((entry) => entry.id),

--- a/src/lib/node-catalog.test.ts
+++ b/src/lib/node-catalog.test.ts
@@ -271,3 +271,15 @@ test("generated asset playground fixture preserves source-model lineage", () => 
   assert.deepEqual(assetNode.upstreamAssetIds, [`node:${modelNode.id}`]);
   assert.equal(assetNode.sourceAssetId, null);
 });
+
+
+test("reference node fixture includes prompt text derived from settings", () => {
+  const referenceEntry = getNodeCatalogEntry("reference", sampleProviders);
+
+  assert.ok(referenceEntry);
+  const fixture = referenceEntry.buildPlaygroundFixture(sampleProviders);
+  const referenceNode = fixture.nodes[0];
+
+  assert.equal(referenceNode?.kind, "reference");
+  assert.ok((referenceNode?.prompt || "").trim().length > 0);
+});

--- a/src/lib/node-catalog.ts
+++ b/src/lib/node-catalog.ts
@@ -1,18 +1,24 @@
-import { createDefaultListNodeSettings, createTextNoteSettings, createTextTemplateNodeSettings } from "@/lib/list-template";
+import {
+  createDefaultListNodeSettings,
+  createReferenceNodeSettings,
+  createTextNoteSettings,
+  createTextTemplateNodeSettings,
+} from "@/lib/list-template";
 import type { ProviderId, ProviderModel, WorkflowNode } from "@/components/workspace/types";
 
 export type NodeCatalogEntryId =
   | "model"
   | "text-note"
+  | "reference"
   | "list"
   | "text-template"
   | "asset-uploaded"
   | "asset-generated";
 
 export type NodeCatalogInsertContext = "canvas" | "model-input" | "template-input";
-export type NodeCatalogCategory = "Generation" | "Text" | "Data" | "Assets";
+export type NodeCatalogCategory = "Generation" | "Text" | "Data" | "Knowledge" | "Assets";
 export type NodeCatalogDisplayMode = "preview" | "compact" | "full" | "resized";
-export type SpawnableNodeCatalogKind = "text-note" | "list" | "text-template";
+export type SpawnableNodeCatalogKind = "text-note" | "reference" | "list" | "text-template";
 
 export type NodeCatalogVariantStatus =
   | "ready"
@@ -305,6 +311,33 @@ function createBaseTextNoteNode(overrides?: Partial<WorkflowNode>): WorkflowNode
   };
 }
 
+
+function createBaseReferenceNode(overrides?: Partial<WorkflowNode>): WorkflowNode {
+  return {
+    id: overrides?.id || "library-reference",
+    label: overrides?.label || "Reference",
+    providerId: overrides?.providerId || "openai",
+    modelId: overrides?.modelId || "gpt-image-1.5",
+    kind: "reference",
+    nodeType: "reference",
+    outputType: "text",
+    prompt: overrides?.prompt || "",
+    settings: overrides?.settings || createReferenceNodeSettings(),
+    sourceAssetId: null,
+    sourceAssetMimeType: null,
+    sourceJobId: null,
+    sourceOutputIndex: null,
+    processingState: null,
+    promptSourceNodeId: null,
+    upstreamNodeIds: overrides?.upstreamNodeIds || [],
+    upstreamAssetIds: overrides?.upstreamAssetIds || [],
+    x: overrides?.x ?? 220,
+    y: overrides?.y ?? 180,
+    displayMode: overrides?.displayMode || "preview",
+    size: overrides?.size || null,
+  };
+}
+
 function createBaseListNode(overrides?: Partial<WorkflowNode>): WorkflowNode {
   return {
     id: overrides?.id || "library-list",
@@ -435,7 +468,7 @@ const baseDefinitions: CatalogBaseDefinition[] = [
       promptSummary: "Use for plain written content, explanations, ideas, captions, or standalone text.",
       payloadSummary: "text-note nodes use the text field.",
     },
-    buildFixture() {
+        buildFixture() {
       const noteNode = createBaseTextNoteNode({
         id: "library-text-note-primary",
         label: "Idea Note",
@@ -454,6 +487,62 @@ const baseDefinitions: CatalogBaseDefinition[] = [
       };
     },
   },
+
+  {
+    id: "reference",
+    label: "Reference Node",
+    shortDescription: "Canonical project entity for a durable real-world subject.",
+    category: "Knowledge",
+    inputSummary: "Manual fields, URL/source notes, optional supporting visuals and attributes.",
+    outputSummary: "Reusable canonical subject context for downstream model and planning nodes.",
+    insertableOnCanvas: true,
+    insertContexts: ["canvas", "model-input"],
+    hasVariants: false,
+    supportedDisplayModes: ["preview", "compact", "full", "resized"],
+    detailCopy:
+      "Reference nodes anchor durable entities such as products, people, locations, brands, and objects. They mix identity data, flexible structured facts, notes, and provenance for reuse across the graph.",
+    settingsSummary: [
+      "Identity and type",
+      "Structured attributes",
+      "Source URL + notes",
+      "Provenance + freshness",
+    ],
+        buildFixture() {
+      const referenceNode = createBaseReferenceNode({
+        id: "library-reference-primary",
+        label: "Horizon Lounge Chair",
+        prompt: "Compact premium lounge chair reference for campaign consistency.",
+        settings: {
+          source: "reference",
+          referenceType: "product",
+          subtitle: "Walnut frame · Moss boucle",
+          status: "enriched",
+          sourceUrl: "https://example.com/products/horizon-lounge-chair",
+          attributes: {
+            dimensions: 'W 82cm × D 88cm × H 76cm',
+            materials: "Walnut, boucle upholstery",
+            configurations: "Ottoman optional",
+          },
+          sourceNotes: "Keep silhouette and warm fabric tones consistent across scenes.",
+          visualAssetIds: [],
+          provenance: "url-import",
+          lastEnrichedAt: "2026-03-13T00:00:00.000Z",
+        },
+        x: 220,
+        y: 140,
+        size: { width: 420, height: 286 },
+        displayMode: "resized",
+      });
+
+      return {
+        primaryNodeId: referenceNode.id,
+        resizePresetSize: { width: 420, height: 286 },
+        nodes: [referenceNode],
+        viewport: { x: -24, y: 30, zoom: 0.88 },
+      };
+    },
+  },
+
   {
     id: "list",
     label: "List / Sheet",
@@ -474,7 +563,7 @@ const baseDefinitions: CatalogBaseDefinition[] = [
       promptSummary: "Use for structured repeated data, rows, tabular information, records, or datasets.",
       payloadSummary: "list nodes use columns and rows.",
     },
-    buildFixture() {
+        buildFixture() {
       const listNode = createBaseListNode({
         id: "library-list-primary",
         label: "Cute Northern UK Animals",
@@ -546,7 +635,7 @@ const baseDefinitions: CatalogBaseDefinition[] = [
       promptSummary: "Use for reusable prompt or writing patterns with fill-in placeholders.",
       payloadSummary: "text-template nodes use templateText with [[variable]] placeholders.",
     },
-    buildFixture() {
+        buildFixture() {
       const listNode = createBaseListNode({
         id: "library-template-list",
         label: "Animal Data",
@@ -614,7 +703,7 @@ const baseDefinitions: CatalogBaseDefinition[] = [
     detailCopy:
       "Uploaded asset nodes point to files already in the project asset store. They act as reusable references for edits, transforms, and comparison flows.",
     settingsSummary: ["Asset preview", "Open in viewer", "Download", "Resizable image framing"],
-    buildFixture() {
+        buildFixture() {
       const assetNode = createBaseAssetNode({
         id: "library-uploaded-asset",
         label: "Uploaded Asset",

--- a/src/lib/node-catalog.ts
+++ b/src/lib/node-catalog.ts
@@ -1,4 +1,5 @@
 import {
+  buildReferencePromptText,
   createDefaultListNodeSettings,
   createReferenceNodeSettings,
   createTextNoteSettings,
@@ -313,6 +314,7 @@ function createBaseTextNoteNode(overrides?: Partial<WorkflowNode>): WorkflowNode
 
 
 function createBaseReferenceNode(overrides?: Partial<WorkflowNode>): WorkflowNode {
+  const referenceSettings = overrides?.settings || createReferenceNodeSettings();
   return {
     id: overrides?.id || "library-reference",
     label: overrides?.label || "Reference",
@@ -321,8 +323,8 @@ function createBaseReferenceNode(overrides?: Partial<WorkflowNode>): WorkflowNod
     kind: "reference",
     nodeType: "reference",
     outputType: "text",
-    prompt: overrides?.prompt || "",
-    settings: overrides?.settings || createReferenceNodeSettings(),
+    prompt: overrides?.prompt || buildReferencePromptText(referenceSettings),
+    settings: referenceSettings,
     sourceAssetId: null,
     sourceAssetMimeType: null,
     sourceJobId: null,


### PR DESCRIPTION
### Motivation
- Introduce a durable, reusable canvas node for canonical project entities (products, people, places, etc.) so subject data is not scattered across notes and prompts.
- Allow reference nodes to be used as prompt/context sources for model nodes and to capture provenance, structured attributes, and enrichment state.

### Description
- Adds a new `WorkflowNode.kind`/`nodeType` and `WorkflowNodeType` value `reference` with typed settings in `src/components/workspace/types.ts` and a `ReferenceNodeSettings` shape.  
- Implements settings helpers `createReferenceNodeSettings` and `getReferenceNodeSettings` in `src/lib/list-template.ts` and wires them into node creation, duplication, and settings parsing flows.  
- Renders a new reference node UI surface by adding styles in `canvas-node.module.css`, editor surface and handlers in `src/components/canvas-nodes/index.tsx`, and preflight rendering classes in `canvas-focus-preflight.tsx`.  
- Integrates reference support across canvas logic including insertion menus, node insertion helpers (`addReferenceNode`), connection rules, node presentation sizing/policies, title chips, primary editor routing, and design semantics.  
- Adds a `Reference Node` catalog entry and fixture in `src/lib/node-catalog.ts` and updates the node catalog tests and insertable entries accordingly.  
- Updates documentation to describe reference node settings and related decisions in `AGENTS.md`, `docs/DATA_MODEL.md`, `docs/DECISIONS.md`, and `docs/UX_CANVAS_AND_ASSETS.md`.

### Testing
- Updated unit test `src/lib/node-catalog.test.ts` to expect the new catalog entries and insertable contexts.  
- Ran the project test suite (`npm test`) and TypeScript type-check (`tsc --noEmit`) locally and the updated unit tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3c72f9c3c8333a8bdcf3d08d7d05b)