### PR TITLE
Show output port for reference nodes and tighten screenshot handoff docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,3 +78,5 @@ Build a local-first Next.js app for node-based media generation and post-process
 - When presenting completed work to the user for repo code changes or app-behavior changes, build a fresh mac app artifact with `npm run package:mac` and report the resulting `.app` and `.zip` paths in the handoff.
 - Do not run `npm run package:mac` for Paper MCP-only work, design-only tasks, copy-only tasks, or other requests that do not change the app code in this repository.
 - Always include screenshots relevant to the feature being presented in the handoff, even when not explicitly requested.
+- In screenshot handoff notes, include a direct markdown image link (`![description](artifact_path)`) and 1-2 bullets describing exactly what the user should verify in that image.
+- Feature screenshots must show the actual surface changed (for example: the edited node/component in its active state), not a generic home or landing view.

--- a/src/components/infinite-canvas.tsx
+++ b/src/components/infinite-canvas.tsx
@@ -1389,6 +1389,7 @@ export function InfiniteCanvas({
           const showOutputPort =
             isListNode ||
             isTextNote ||
+            isReferenceNode ||
             isOperatorNode ||
             (node.kind === "asset-source" && !isModelNode) ||
             (isModelNode && node.outputType !== "text" && Boolean(node.hasStartedJob));


### PR DESCRIPTION
### Motivation
- Reference nodes should expose an output port so they can be wired into the canvas graph like other nodes. 
- Handoff guidance needs stricter screenshot instructions to ensure reviewers see the exact changed surface and a direct image link.

### Description
- Add `isReferenceNode` detection in `InfiniteCanvas` and include it in the `showOutputPort` condition so reference nodes render an output port. 
- Update `AGENTS.md` to require a direct markdown image link (`![description](artifact_path)`) in screenshot handoff notes and to require that feature screenshots show the actual changed surface.

### Testing
- Ran TypeScript build/compile checks (`npm run build`) which completed successfully. 
- Ran linting (`npm run lint`) and the existing unit test suite (`npm test`), both of which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b43c2d68348333b9b05f0787f968a5)